### PR TITLE
Alter test workflow so the tests match the installed version

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -26,7 +26,7 @@ jobs:
     env:
       CI_COMMIT_EMAIL: "ci-runner@input4mips-validation.invalid"
     steps:
-      - name: Check out repository
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/install-conda.yaml
+++ b/.github/workflows/install-conda.yaml
@@ -19,7 +19,7 @@ jobs:
         # os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         os: ["ubuntu-latest", "macos-latest"]
         python-version: [ "3.9", "3.10", "3.11" ]
-        # Check both 'library' install and the 'application' (i.e. locked) install
+        # Check both the 'library' and the 'application' (i.e. locked package)
         install-target: ["input4mips-validation", "input4mips-validation-locked"]
 
     steps:
@@ -35,8 +35,15 @@ jobs:
           -c conda-forge
           ${{ matrix.install-target }}
         init-shell: bash
+    - name: Get version
+      run: |
+        INSTALLED_VERSION=`python -c 'import input4mips_validation; print(f"v{input4mips_validation.__version__}")'`
+        echo $INSTALLED_VERSION
+        echo "INSTALLED_VERSION=$INSTALLED_VERSION" >> $GITHUB_ENV
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        ref: ${{ env.INSTALLED_VERSION }}
     - name: Test installation
       shell: bash -leo pipefail {0}
       run: |

--- a/.github/workflows/install-conda.yaml
+++ b/.github/workflows/install-conda.yaml
@@ -1,3 +1,10 @@
+# Test installation of the latest version from conda/mamba works.
+# We make sure that we run the tests that apply to the version we installed,
+# rather than the latest tests in main.
+# The reason we do this, is that we want this workflow to test
+# that installing from PyPI/conda leads to a correct installation.
+# If we tested against main, the tests could fail
+# because the tests from main require the new features in main to pass.
 name: Test installation conda
 
 on:
@@ -43,13 +50,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
-        # Make sure that we run the tests that apply to the version we installed.
-        # If you don't do this, the tests can fail
-        # because tests from main, that rely on new features,
-        # will be used to check an old version, so there will likely be failures.
-        # That isn't what we want this workflow to test.
-        # We want this workflow to test
-        # that installing from PyPI/conda leads to a correct installation.
         ref: ${{ env.INSTALLED_VERSION }}
     - name: Test installation
       shell: bash -leo pipefail {0}

--- a/.github/workflows/install-conda.yaml
+++ b/.github/workflows/install-conda.yaml
@@ -43,6 +43,13 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
+        # Make sure that we run the tests that apply to the version we installed.
+        # If you don't do this, the tests can fail
+        # because tests from main, that rely on new features,
+        # will be used to check an old version, so there will likely be failures.
+        # That isn't what we want this workflow to test.
+        # We want this workflow to test
+        # that installing from PyPI/conda leads to a correct installation.
         ref: ${{ env.INSTALLED_VERSION }}
     - name: Test installation
       shell: bash -leo pipefail {0}

--- a/.github/workflows/install-pypi.yaml
+++ b/.github/workflows/install-pypi.yaml
@@ -52,8 +52,14 @@ jobs:
       if: matrix.os != 'windows-latest'
       run: |
         if grep -q "WARN" stderr.txt; then echo "Warnings in pip install output" && cat stderr.txt && exit 1; else exit 0; fi
+    - name: Get version
+      run: |
+        INSTALLED_VERSION=`python -c 'import input4mips_validation; print(f"v{input4mips_validation.__version__}")'`
+        echo $INSTALLED_VERSION
+        echo "INSTALLED_VERSION=$INSTALLED_VERSION" >> $GITHUB_ENV
     - name: Checkout repository
       uses: actions/checkout@v4
+      ref: ${{ env.INSTALLED_VERSION }}
     - name: Test installation
       run: |
         which python

--- a/.github/workflows/install-pypi.yaml
+++ b/.github/workflows/install-pypi.yaml
@@ -60,6 +60,13 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
+        # Make sure that we run the tests that apply to the version we installed.
+        # If you don't do this, the tests can fail
+        # because tests from main, that rely on new features,
+        # will be used to check an old version, so there will likely be failures.
+        # That isn't what we want this workflow to test.
+        # We want this workflow to test
+        # that installing from PyPI/conda leads to a correct installation.
         ref: ${{ env.INSTALLED_VERSION }}
     - name: Test installation
       run: |

--- a/.github/workflows/install-pypi.yaml
+++ b/.github/workflows/install-pypi.yaml
@@ -1,3 +1,10 @@
+# Test installation of the latest version from PyPI works.
+# We make sure that we run the tests that apply to the version we installed,
+# rather than the latest tests in main.
+# The reason we do this, is that we want this workflow to test
+# that installing from PyPI/conda leads to a correct installation.
+# If we tested against main, the tests could fail
+# because the tests from main require the new features in main to pass.
 name: Test installation PyPI
 
 on:
@@ -60,13 +67,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
-        # Make sure that we run the tests that apply to the version we installed.
-        # If you don't do this, the tests can fail
-        # because tests from main, that rely on new features,
-        # will be used to check an old version, so there will likely be failures.
-        # That isn't what we want this workflow to test.
-        # We want this workflow to test
-        # that installing from PyPI/conda leads to a correct installation.
         ref: ${{ env.INSTALLED_VERSION }}
     - name: Test installation
       run: |

--- a/.github/workflows/install-pypi.yaml
+++ b/.github/workflows/install-pypi.yaml
@@ -59,7 +59,8 @@ jobs:
         echo "INSTALLED_VERSION=$INSTALLED_VERSION" >> $GITHUB_ENV
     - name: Checkout repository
       uses: actions/checkout@v4
-      ref: ${{ env.INSTALLED_VERSION }}
+      with:
+        ref: ${{ env.INSTALLED_VERSION }}
     - name: Test installation
       run: |
         which python

--- a/changelog/49.trivial.md
+++ b/changelog/49.trivial.md
@@ -1,0 +1,1 @@
+Updated the test workflow so it applies the tests which match the installed version, rather than the latest tests from main (which should fail, because they test features that aren't in released versions).


### PR DESCRIPTION
## Description

If you don't do this, the tests can fail because tests from main will be used to check an old version. That isn't what we want this workflow to test. We want this workflow to test that installing from PyPI/conda leads to a correct installation.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added (N/A)
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
